### PR TITLE
LINT-55(HOTFIX): Incorrect import order working with aliases.

### DIFF
--- a/rules/import-order/index.js
+++ b/rules/import-order/index.js
@@ -10,7 +10,7 @@ module.exports = {
             {
                 pathGroups: layersLib.FS_LAYERS.map(
                     (layer) => ({
-                        pattern: `${layer}/**` ,
+                        pattern: `**/${layer}/**` ,
                         group: "internal",
                         position: "after",
                     }),

--- a/rules/import-order/index.test.js
+++ b/rules/import-order/index.test.js
@@ -12,6 +12,8 @@ describe("Import order:", () => {
 
     it("should lint with errors.", async () => {
         const report = await eslint.lintText(`
+        import { Cart } from "@/entities/cart"; // 6 - Alias
+        import { Input } from "~/shared/ui"; // 7 - Alias
         import { getSmth } from "./lib"; // 1
         import axios from "axios";
         import { data } from "../fixtures"; // 2
@@ -22,7 +24,7 @@ describe("Import order:", () => {
         import { debounce } from "shared/lib/fp";
         `);
 
-        assert.strictEqual(report[0].errorCount, 5);
+        assert.strictEqual(report[0].errorCount, 7);
     });
 
     it("should lint without errors.", async () => {
@@ -31,6 +33,8 @@ describe("Import order:", () => {
         import { Header } from "widgets/header";             // 2.1) Layers: widgets
         import { LoginForm } from "features/login-form";     // 2.2) Layers: features
         import { authModel } from "entities/auth";           // 2.3) Layers: entities
+        import { Cart } from "@/entities/cart";              // Layers: entities - Alias
+        import { Input } from "~/shared/ui";                 // Layers: shared - Alias
         import { Button } from "shared/ui";                  // 2.4) Layers: shared
         import { debounce } from "shared/lib/fp";            // 2.4) Layers: shared
         import { data } from "../fixtures";                  // 3) parent


### PR DESCRIPTION
## Description
Добавлено:
- Поддержка корневых альясов для import-order
- Тесты на корневые альясы для import-order

Example:
```js
        import { Cart } from "@/entities/cart";
        import { Input } from "~/shared/ui";
```

## References
#55 #58
https://github.com/feature-sliced/eslint-config/discussions/55#discussioncomment-1887446

## Checklist
- [x] Description added
- [x] Self-reviewed
- [x] CI pass
