### PR TITLE
LINT-75(feedback): allow publicAPI for shared segments with _prefix

### DIFF
--- a/rules/public-api/index.js
+++ b/rules/public-api/index.js
@@ -45,9 +45,9 @@ module.exports = {
                     `**/node_modules/**`,
 
                     /**
-                     * IDDQD
+                     * allow custom shared segments with _prefix
                      */
-                    `**/_*/**`
+                    `**/*shared/_*/**`
                 ],
             }],
     },

--- a/rules/public-api/index.js
+++ b/rules/public-api/index.js
@@ -47,7 +47,7 @@ module.exports = {
                     /**
                      * allow custom shared segments with _prefix
                      */
-                    `**/*shared/_*/*`,
+                    `**/*shared/_*/*`
                 ],
             }],
     },

--- a/rules/public-api/index.js
+++ b/rules/public-api/index.js
@@ -47,6 +47,7 @@ module.exports = {
                     /**
                      * allow custom shared segments with _prefix
                      */
+                    `**/*shared/_*`,
                     `**/*shared/_*/*`
                 ],
             }],

--- a/rules/public-api/index.js
+++ b/rules/public-api/index.js
@@ -47,7 +47,7 @@ module.exports = {
                     /**
                      * allow custom shared segments with _prefix
                      */
-                    `**/*shared/_*/**`
+                    `**/*shared/_*/*`,
                 ],
             }],
     },

--- a/rules/public-api/index.js
+++ b/rules/public-api/index.js
@@ -42,7 +42,12 @@ module.exports = {
                     `**/*shared/*(${FS_SEGMENTS_REG})`,
 
                     /** allow global modules */
-                    `**/node_modules/**`
+                    `**/node_modules/**`,
+
+                    /**
+                     * IDDQD
+                     */
+                    `**/_*/**`
                 ],
             }],
     },

--- a/rules/public-api/index.test.js
+++ b/rules/public-api/index.test.js
@@ -15,20 +15,27 @@ describe("Allow publicAPI for shared segments with _prefix:", () => {
           const report = await eslint.lintText(`
           import { One } from "shared/_route/one";
           import { Two } from "@shared/_note/two";
-          import { Four } from "shared/_note/three/four";
           `,
           { filePath: "src/app/ui/index.js" });
           assert.strictEqual(report[0].errorCount, 0);
+    });
+
+    it("import inner module with _prefix should lint with errors", async () => {
+      const report = await eslint.lintText(`
+            import { Five } from "@shared/_note/two/five";
+            import { Four } from "shared/_note/three/four";
+            `,
+        { filePath: "src/app/ui/index.js" });
+      assert.strictEqual(report[0].errorCount, 2);
     });
 
     it("without prefix should lint with errors", async () => {
         const report = await eslint.lintText(`
         import { One } from "shared/route/one";
         import { Two } from "@shared/note/two";
-        import { Four } from "shared/note/three/four";
         `,
         { filePath: "src/app/ui/index.js" });
-        assert.strictEqual(report[0].errorCount, 3);
+        assert.strictEqual(report[0].errorCount, 2);
     });
 })
 

--- a/rules/public-api/index.test.js
+++ b/rules/public-api/index.test.js
@@ -12,21 +12,21 @@ const eslint = new ESLint({
 
 describe("Allow publicAPI for shared segments with _prefix:", () => {
     it("with _prefix should lint without errors", async () => {
-          const report = await eslint.lintText(`
-          import { One } from "shared/_route/one";
-          import { Two } from "@shared/_note/two";
-          `,
-          { filePath: "src/app/ui/index.js" });
-          assert.strictEqual(report[0].errorCount, 0);
+        const report = await eslint.lintText(`
+        import { One } from "shared/_route/one";
+        import { Two } from "@shared/_note/two";
+        `,
+            {filePath: "src/app/ui/index.js"});
+        assert.strictEqual(report[0].errorCount, 0);
     });
 
     it("import inner module with _prefix should lint with errors", async () => {
-      const report = await eslint.lintText(`
-            import { Five } from "@shared/_note/two/five";
-            import { Four } from "shared/_note/three/four";
-            `,
-        { filePath: "src/app/ui/index.js" });
-      assert.strictEqual(report[0].errorCount, 2);
+        const report = await eslint.lintText(`
+        import { Five } from "@shared/_note/two/five";
+        import { Four } from "shared/_note/three/four";
+        `,
+            {filePath: "src/app/ui/index.js"});
+        assert.strictEqual(report[0].errorCount, 2);
     });
 
     it("without prefix should lint with errors", async () => {
@@ -34,10 +34,10 @@ describe("Allow publicAPI for shared segments with _prefix:", () => {
         import { One } from "shared/route/one";
         import { Two } from "@shared/note/two";
         `,
-        { filePath: "src/app/ui/index.js" });
+            {filePath: "src/app/ui/index.js"});
         assert.strictEqual(report[0].errorCount, 2);
     });
-})
+});
 
 describe("PublicAPI import boundaries:", () => {
     it("Should lint PublicAPI boundaries with errors.", async () => {

--- a/rules/public-api/index.test.js
+++ b/rules/public-api/index.test.js
@@ -10,20 +10,25 @@ const eslint = new ESLint({
     ),
 });
 
-describe("Allow publicAPI cheats:", () => {
-    it("with cheats should ling without errors", async () => {
+describe("Allow publicAPI for shared segments with _prefix:", () => {
+    it("with _prefix should lint without errors", async () => {
+          const report = await eslint.lintText(`
+          import { One } from "shared/_route/one";
+          import { Two } from "@shared/_note/two";
+          import { Four } from "shared/_note/three/four";
+          `,
+          { filePath: "src/app/ui/index.js" });
+          assert.strictEqual(report[0].errorCount, 0);
+    });
+
+    it("without prefix should lint with errors", async () => {
         const report = await eslint.lintText(`
-        import { Issues } from "pages/_issues/ui";
-        import { IssueDetails } from "widgets/_issue-details/ui/details";
-        import { AuthForm } from "features/_auth-form/ui/form";
-        import { Button } from "shared/ui/_button/button";
-        import { saveOrder } from "entities/order/_model/actions";
-        import { orderModel } from "entities/order/_model";
-        import { TicketCard } from "@src/entities/_ticket/ui";
-        import { Ticket } from "@src/entities/_ticket/ui.tsx";
+        import { One } from "shared/route/one";
+        import { Two } from "@shared/note/two";
+        import { Four } from "shared/note/three/four";
         `,
-            { filePath: "src/app/ui/index.js" });
-        assert.strictEqual(report[0].errorCount, 0);
+        { filePath: "src/app/ui/index.js" });
+        assert.strictEqual(report[0].errorCount, 3);
     });
 })
 

--- a/rules/public-api/index.test.js
+++ b/rules/public-api/index.test.js
@@ -15,6 +15,7 @@ describe("Allow publicAPI for shared segments with _prefix:", () => {
         const report = await eslint.lintText(`
         import { One } from "shared/_route/one";
         import { Two } from "@shared/_note/two";
+        import { Route } from "shared/_route";
         `,
             {filePath: "src/app/ui/index.js"});
         assert.strictEqual(report[0].errorCount, 0);
@@ -24,9 +25,10 @@ describe("Allow publicAPI for shared segments with _prefix:", () => {
         const report = await eslint.lintText(`
         import { Five } from "@shared/_note/two/five";
         import { Four } from "shared/_note/three/four";
+        import { Route } from "shared/route";
         `,
             {filePath: "src/app/ui/index.js"});
-        assert.strictEqual(report[0].errorCount, 2);
+        assert.strictEqual(report[0].errorCount, 3);
     });
 
     it("without prefix should lint with errors", async () => {

--- a/rules/public-api/index.test.js
+++ b/rules/public-api/index.test.js
@@ -10,6 +10,23 @@ const eslint = new ESLint({
     ),
 });
 
+describe("Allow publicAPI cheats:", () => {
+    it("with cheats should ling without errors", async () => {
+        const report = await eslint.lintText(`
+        import { Issues } from "pages/_issues/ui";
+        import { IssueDetails } from "widgets/_issue-details/ui/details";
+        import { AuthForm } from "features/_auth-form/ui/form";
+        import { Button } from "shared/ui/_button/button";
+        import { saveOrder } from "entities/order/_model/actions";
+        import { orderModel } from "entities/order/_model";
+        import { TicketCard } from "@src/entities/_ticket/ui";
+        import { Ticket } from "@src/entities/_ticket/ui.tsx";
+        `,
+            { filePath: "src/app/ui/index.js" });
+        assert.strictEqual(report[0].errorCount, 0);
+    });
+})
+
 describe("PublicAPI import boundaries:", () => {
     it("Should lint PublicAPI boundaries with errors.", async () => {
         const report = await eslint.lintText(`

--- a/rules/public-api/lite.js
+++ b/rules/public-api/lite.js
@@ -32,14 +32,14 @@ module.exports = {
                      * @example
                      * 'shared/ui/button' // Pass
                      */
-                    `**/?(*)shared/*(${FS_SEGMENTS_REG})/!(${FS_SEGMENTS_REG})`,
+                    `**/*shared/*(${FS_SEGMENTS_REG})/!(${FS_SEGMENTS_REG})`,
 
                     /**
                      * Allow import from segments in shared
                      * @example
                      * 'shared/ui' // Pass
                      */
-                    `**/?(*)shared/*(${FS_SEGMENTS_REG})`,
+                    `**/*shared/*(${FS_SEGMENTS_REG})`,
 
                     /** allow global modules */
                     `**/node_modules/**`,
@@ -47,7 +47,7 @@ module.exports = {
                     /**
                      * allow custom shared segments with _prefix
                      */
-                    `**/?(*)shared/_*/**`,
+                    `**/*shared/_*/*`,
 
                     /**
                      *  Used for allow import local modules

--- a/rules/public-api/lite.js
+++ b/rules/public-api/lite.js
@@ -45,11 +45,17 @@ module.exports = {
                     `**/node_modules/**`,
 
                     /**
+                     * IDDQD
+                     */
+                    `**/_*/**`,
+
+                    /**
                      *  Used for allow import local modules
                      * @example
                      * './model/something' // Pass
                      */
                     `./**`
+
                 ],
             }],
     },

--- a/rules/public-api/lite.js
+++ b/rules/public-api/lite.js
@@ -32,22 +32,22 @@ module.exports = {
                      * @example
                      * 'shared/ui/button' // Pass
                      */
-                    `**/*shared/*(${FS_SEGMENTS_REG})/!(${FS_SEGMENTS_REG})`,
+                    `**/?(*)shared/*(${FS_SEGMENTS_REG})/!(${FS_SEGMENTS_REG})`,
 
                     /**
                      * Allow import from segments in shared
                      * @example
                      * 'shared/ui' // Pass
                      */
-                    `**/*shared/*(${FS_SEGMENTS_REG})`,
+                    `**/?(*)shared/*(${FS_SEGMENTS_REG})`,
 
                     /** allow global modules */
                     `**/node_modules/**`,
 
                     /**
-                     * IDDQD
+                     * allow custom shared segments with _prefix
                      */
-                    `**/_*/**`,
+                    `**/?(*)shared/_*/**`,
 
                     /**
                      *  Used for allow import local modules

--- a/rules/public-api/lite.js
+++ b/rules/public-api/lite.js
@@ -47,6 +47,7 @@ module.exports = {
                     /**
                      * allow custom shared segments with _prefix
                      */
+                    `**/*shared/_*`,
                     `**/*shared/_*/*`,
 
                     /**

--- a/rules/public-api/lite.test.js
+++ b/rules/public-api/lite.test.js
@@ -48,21 +48,26 @@ describe("Lite PublicAPI:", () => {
     });
 })
 
-describe("Allow publicAPI cheats:", () => {
-    it("with cheats should ling without errors", async () => {
-        const report = await eslint.lintText(`
-        import { Issues } from "pages/_issues/ui";
-        import { IssueDetails } from "widgets/_issue-details/ui/details";
-        import { AuthForm } from "features/_auth-form/ui/form";
-        import { Button } from "shared/ui/_button/button";
-        import { saveOrder } from "entities/order/_model/actions";
-        import { orderModel } from "entities/order/_model";
-        import { TicketCard } from "@src/entities/_ticket/ui";
-        import { Ticket } from "@src/entities/_ticket/ui.tsx";
+describe("Allow publicAPI for shared segments with _prefix:", () => {
+  it("with _prefix should lint without errors", async () => {
+    const report = await eslint.lintText(`
+          import { One } from "shared/_route/one";
+          import { Two } from "@shared/_note/two";
+          import { Four } from "shared/_note/three/four";
+          `,
+      { filePath: "src/app/ui/index.js" });
+    assert.strictEqual(report[0].errorCount, 0);
+  });
+
+  it("without prefix should lint with errors", async () => {
+    const report = await eslint.lintText(`
+        import { One } from "shared/route/one";
+        import { Two } from "@shared/note/two";
+        import { Four } from "shared/note/three/four";
         `,
-            { filePath: "src/app/ui/index.js" });
-        assert.strictEqual(report[0].errorCount, 0);
-    });
+      { filePath: "src/app/ui/index.js" });
+    assert.strictEqual(report[0].errorCount, 3);
+  });
 })
 
 describe("PublicAPI import boundaries:", () => {

--- a/rules/public-api/lite.test.js
+++ b/rules/public-api/lite.test.js
@@ -49,33 +49,33 @@ describe("Lite PublicAPI:", () => {
 })
 
 describe("Allow publicAPI for shared segments with _prefix:", () => {
-  it("with _prefix should lint without errors", async () => {
-    const report = await eslint.lintText(`
-          import { One } from "shared/_route/one";
-          import { Two } from "@shared/_note/two";
-          `,
-      { filePath: "src/app/ui/index.js" });
-    assert.strictEqual(report[0].errorCount, 0);
-  });
+    it("with _prefix should lint without errors", async () => {
+        const report = await eslint.lintText(`
+        import { One } from "shared/_route/one";
+        import { Two } from "@shared/_note/two";
+        `,
+            {filePath: "src/app/ui/index.js"});
+        assert.strictEqual(report[0].errorCount, 0);
+    });
 
-  it("import inner module with _prefix should lint with errors", async () => {
-    const report = await eslint.lintText(`
-            import { Five } from "@shared/_note/two/five";
-            import { Four } from "shared/_note/three/four";
-            `,
-      { filePath: "src/app/ui/index.js" });
-    assert.strictEqual(report[0].errorCount, 2);
-  });
+    it("import inner module with _prefix should lint with errors", async () => {
+        const report = await eslint.lintText(`
+        import { Five } from "@shared/_note/two/five";
+        import { Four } from "shared/_note/three/four";
+        `,
+            {filePath: "src/app/ui/index.js"});
+        assert.strictEqual(report[0].errorCount, 2);
+    });
 
-  it("without prefix should lint with errors", async () => {
-    const report = await eslint.lintText(`
+    it("without prefix should lint with errors", async () => {
+        const report = await eslint.lintText(`
         import { One } from "shared/route/one";
         import { Two } from "@shared/note/two";
         `,
-      { filePath: "src/app/ui/index.js" });
-    assert.strictEqual(report[0].errorCount, 2);
-  });
-})
+            {filePath: "src/app/ui/index.js"});
+        assert.strictEqual(report[0].errorCount, 2);
+    });
+});
 
 describe("PublicAPI import boundaries:", () => {
     it("Should lint PublicAPI boundaries with errors.", async () => {

--- a/rules/public-api/lite.test.js
+++ b/rules/public-api/lite.test.js
@@ -48,6 +48,23 @@ describe("Lite PublicAPI:", () => {
     });
 })
 
+describe("Allow publicAPI cheats:", () => {
+    it("with cheats should ling without errors", async () => {
+        const report = await eslint.lintText(`
+        import { Issues } from "pages/_issues/ui";
+        import { IssueDetails } from "widgets/_issue-details/ui/details";
+        import { AuthForm } from "features/_auth-form/ui/form";
+        import { Button } from "shared/ui/_button/button";
+        import { saveOrder } from "entities/order/_model/actions";
+        import { orderModel } from "entities/order/_model";
+        import { TicketCard } from "@src/entities/_ticket/ui";
+        import { Ticket } from "@src/entities/_ticket/ui.tsx";
+        `,
+            { filePath: "src/app/ui/index.js" });
+        assert.strictEqual(report[0].errorCount, 0);
+    });
+})
+
 describe("PublicAPI import boundaries:", () => {
     it("Should lint PublicAPI boundaries with errors.", async () => {
         const report = await eslint.lintText(`

--- a/rules/public-api/lite.test.js
+++ b/rules/public-api/lite.test.js
@@ -53,20 +53,27 @@ describe("Allow publicAPI for shared segments with _prefix:", () => {
     const report = await eslint.lintText(`
           import { One } from "shared/_route/one";
           import { Two } from "@shared/_note/two";
-          import { Four } from "shared/_note/three/four";
           `,
       { filePath: "src/app/ui/index.js" });
     assert.strictEqual(report[0].errorCount, 0);
+  });
+
+  it("import inner module with _prefix should lint with errors", async () => {
+    const report = await eslint.lintText(`
+            import { Five } from "@shared/_note/two/five";
+            import { Four } from "shared/_note/three/four";
+            `,
+      { filePath: "src/app/ui/index.js" });
+    assert.strictEqual(report[0].errorCount, 2);
   });
 
   it("without prefix should lint with errors", async () => {
     const report = await eslint.lintText(`
         import { One } from "shared/route/one";
         import { Two } from "@shared/note/two";
-        import { Four } from "shared/note/three/four";
         `,
       { filePath: "src/app/ui/index.js" });
-    assert.strictEqual(report[0].errorCount, 3);
+    assert.strictEqual(report[0].errorCount, 2);
   });
 })
 

--- a/rules/public-api/lite.test.js
+++ b/rules/public-api/lite.test.js
@@ -53,6 +53,7 @@ describe("Allow publicAPI for shared segments with _prefix:", () => {
         const report = await eslint.lintText(`
         import { One } from "shared/_route/one";
         import { Two } from "@shared/_note/two";
+        import { Route } from "shared/_route";
         `,
             {filePath: "src/app/ui/index.js"});
         assert.strictEqual(report[0].errorCount, 0);
@@ -62,9 +63,10 @@ describe("Allow publicAPI for shared segments with _prefix:", () => {
         const report = await eslint.lintText(`
         import { Five } from "@shared/_note/two/five";
         import { Four } from "shared/_note/three/four";
+        import { Route } from "shared/route";
         `,
             {filePath: "src/app/ui/index.js"});
-        assert.strictEqual(report[0].errorCount, 2);
+        assert.strictEqual(report[0].errorCount, 3);
     });
 
     it("without prefix should lint with errors", async () => {


### PR DESCRIPTION
## Description
Добавлена возможность использования кастомных сегментов с _ префиксом.
## References
https://github.com/feature-sliced/eslint-config/discussions/75#discussioncomment-2108885
## Checklist
- [x] Description added
- [x] Self-reviewed
- [x] CI pass
