### PR TITLE
LINT-75(feedback): Incorrect sorting for layer root imports

### DIFF
--- a/rules/import-order/experimental.js
+++ b/rules/import-order/experimental.js
@@ -20,7 +20,7 @@ module.exports = {
                 'newlines-between': 'always',
                 pathGroups: REVERSED_FS_LAYERS.map(
                     (layer) => ({
-                        pattern: `**/?(*)${layer}/**` ,
+                        pattern: `**/?(*)${layer}{,/**}`,
                         group: "internal",
                         position: "after",
                     }),

--- a/rules/import-order/experimental.test.js
+++ b/rules/import-order/experimental.test.js
@@ -37,6 +37,7 @@ describe("Import order experimental:", () => {
         import { model } from "shared/model";
         import { Button } from "shared/ui";
         
+        import { globalEntities } from "entities";
         import { authModel } from "entities/auth";
         import { Cart } from "entities/cart";
         import { One } from "entities/one";

--- a/rules/import-order/experimental.test.js
+++ b/rules/import-order/experimental.test.js
@@ -33,6 +33,7 @@ describe("Import order experimental:", () => {
         const report = await eslint.lintText(`
         import axios from "axios";
         
+        import { Shared } from "shared";
         import { debounce } from "shared/lib/fp";            
         import { model } from "shared/model";
         import { Button } from "shared/ui";
@@ -45,6 +46,7 @@ describe("Import order experimental:", () => {
         
         import { LoginForm } from "features/login-form";
         
+        import { Widgets } from "widgets";
         import { Header } from "widgets/header";
         import { Zero } from "widgets/zero";
         
@@ -72,6 +74,7 @@ describe("Import order experimental:", () => {
         
         import { LoginForm } from "~features/login-form";
         
+        import { Widgets } from "~widgets";
         import { Header } from "~widgets/header";
         import { Zero } from "~widgets/zero";
         
@@ -99,6 +102,7 @@ describe("Import order experimental:", () => {
         
         import { LoginForm } from "~/features/login-form";
         
+        import { Widgets } from "~/widgets";
         import { Header } from "~/widgets/header";
         import { Zero } from "~/widgets/zero";
         

--- a/rules/import-order/index.js
+++ b/rules/import-order/index.js
@@ -14,7 +14,7 @@ module.exports = {
                 },
                 pathGroups: layersLib.FS_LAYERS.map(
                     (layer) => ({
-                        pattern: `**/?(*)${layer}/**` ,
+                        pattern: `**/?(*)${layer}{,/**}`,
                         group: "internal",
                         position: "after",
                     }),

--- a/rules/import-order/index.test.js
+++ b/rules/import-order/index.test.js
@@ -58,12 +58,14 @@ describe("Import order:", () => {
         // not used in real, but test aliases support 
         import axios from "axios";                           // 1) external libs
         import { Zero } from "@widgets/zero";                // 2.1) Layers: widget - Alias
+        import { Widgets } from "widgets";                   // 2.1) Layers: widgets
         import { Header } from "widgets/header";             // 2.1) Layers: widgets
         import { LoginForm } from "features/login-form";     // 2.2) Layers: features
         import { Cart } from "@/entities/cart";              // 2.3) Layers: entities - Alias
         import { One } from "@entities/one";                 // 2.3) Layers: entities - Alias
         import { Two } from "@entities/two";                 // 2.3) Layers: entities - Alias
         import { authModel } from "entities/auth";           // 2.3) Layers: entities
+        import { Shared } from "shared";                     // 2.4) Layers: shared
         import { debounce } from "shared/lib/fp";            // 2.4) Layers: shared
         import { Button } from "shared/ui";                  // 2.4) Layers: shared
         import { Input } from "~/shared/ui";                 // 2.4) Layers: shared - Alias
@@ -86,9 +88,59 @@ describe("Import order:", () => {
 
     it("aliased layers should lint without errors.", async () => {
         const report = await eslint.lintText(`
+        import { Widgets } from "@widgets";
         import { First } from '@features/first';
         import { Second } from '@entities/second';
         import { Third } from '@shared/third';
+        `);
+
+        assert.strictEqual(report[0].errorCount, 0);
+    });
+
+    it("~aliased should lint without errors.", async () => {
+        const report = await eslint.lintText(`
+        import axios from "axios";
+        
+        import { debounce } from "~shared/lib/fp";            
+        import { model } from "~shared/model";
+        import { Button } from "~shared/ui";
+        
+        import { authModel } from "~entities/auth";
+        import { Cart } from "~entities/cart";
+        import { One } from "~entities/one";
+        import { Two } from "~entities/two";
+        
+        import { LoginForm } from "~features/login-form";
+        
+        import { Widgets } from "~widgets";
+        import { Header } from "~widgets/header";
+        import { Zero } from "~widgets/zero";
+        
+        import { data } from "../fixtures";
+        
+        import { getSmth } from "./lib";
+        `);
+
+        assert.strictEqual(report[0].errorCount, 0);
+    });
+
+
+    it("~/aliased should lint without errors.", async () => {
+        const report = await eslint.lintText(`
+        import axios from "axios";
+        import { Widgets } from "~/widgets";
+        import { Header } from "~/widgets/header";
+        import { Zero } from "~/widgets/zero";
+        import { LoginForm } from "~/features/login-form";        
+        import { authModel } from "~/entities/auth";
+        import { Cart } from "~/entities/cart";
+        import { One } from "~/entities/one";
+        import { Two } from "~/entities/two";        
+        import { debounce } from "~/shared/lib/fp";            
+        import { model } from "~/shared/model";
+        import { Button } from "~/shared/ui";
+        import { data } from "../fixtures";
+        import { getSmth } from "./lib";
         `);
 
         assert.strictEqual(report[0].errorCount, 0);

--- a/rules/import-order/index.test.js
+++ b/rules/import-order/index.test.js
@@ -36,6 +36,7 @@ describe("Import order:", () => {
         import { Header } from "widgets/header";             // 2.1) Layers: widgets
         import { Zero } from "widgets/zero";                 // 2.1) Layers: widget 
         import { LoginForm } from "features/login-form";     // 2.2) Layers: features
+        import { globalEntities } from "entities";           // 2.4) Layers: entities
         import { authModel } from "entities/auth";           // 2.4) Layers: entities
         import { Cart } from "entities/cart";                // 2.4) Layers: entities 
         import { One } from "entities/one";                  // 2.4) Layers: entities 
@@ -46,6 +47,9 @@ describe("Import order:", () => {
         import { data } from "../fixtures";                  // 3) parent
         import { getSmth } from "./lib";                     // 4) sibling
         `);
+
+        console.log(report[0]);
+
         assert.strictEqual(report[0].errorCount, 0);
     });
 
@@ -68,6 +72,9 @@ describe("Import order:", () => {
         import { data } from "../fixtures";                  // 3) parent
         import { getSmth } from "./lib";                     // 4) sibling
         `);
+
+
+
         assert.strictEqual(report[0].errorCount, 0);
     });
 

--- a/rules/import-order/index.test.js
+++ b/rules/import-order/index.test.js
@@ -48,8 +48,6 @@ describe("Import order:", () => {
         import { getSmth } from "./lib";                     // 4) sibling
         `);
 
-        console.log(report[0]);
-
         assert.strictEqual(report[0].errorCount, 0);
     });
 
@@ -72,8 +70,6 @@ describe("Import order:", () => {
         import { data } from "../fixtures";                  // 3) parent
         import { getSmth } from "./lib";                     // 4) sibling
         `);
-
-
 
         assert.strictEqual(report[0].errorCount, 0);
     });

--- a/rules/import-order/index.test.js
+++ b/rules/import-order/index.test.js
@@ -100,24 +100,18 @@ describe("Import order:", () => {
     it("~aliased should lint without errors.", async () => {
         const report = await eslint.lintText(`
         import axios from "axios";
-        
-        import { debounce } from "~shared/lib/fp";            
-        import { model } from "~shared/model";
-        import { Button } from "~shared/ui";
-        
+        import { Widgets } from "~widgets";
+        import { Header } from "~widgets/header";
+        import { Zero } from "~widgets/zero";        
+        import { LoginForm } from "~features/login-form";        
         import { authModel } from "~entities/auth";
         import { Cart } from "~entities/cart";
         import { One } from "~entities/one";
-        import { Two } from "~entities/two";
-        
-        import { LoginForm } from "~features/login-form";
-        
-        import { Widgets } from "~widgets";
-        import { Header } from "~widgets/header";
-        import { Zero } from "~widgets/zero";
-        
+        import { Two } from "~entities/two";        
+        import { debounce } from "~shared/lib/fp";            
+        import { model } from "~shared/model";
+        import { Button } from "~shared/ui";
         import { data } from "../fixtures";
-        
         import { getSmth } from "./lib";
         `);
 


### PR DESCRIPTION
## Description
Добавлено:
Поддержка сортировкой импортов из корня слоя 

Example: 
```js
import { globalEntities } from "entities";
```

## References
https://github.com/feature-sliced/eslint-config/discussions/75#discussioncomment-1977273


## Checklist
- [x] Description added
- [x] Self-reviewed
- [x] CI pass
