### PR TITLE
fix: add app layer rule

### DIFF
--- a/rules/layers-slices/index.js
+++ b/rules/layers-slices/index.js
@@ -6,10 +6,16 @@ const getNotSharedLayersRules = () =>
         allow: layersLib.getLowerLayers(layer),
     }));
 
-const sharedLayerRule = {
-    from: "shared",
-    allow: "shared",
-};
+const slicelessLayerRules = [
+    {
+        from: "shared",
+        allow: "shared",
+    },
+    {
+        from: "app",
+        allow: "app",
+    }
+];
 
 const getLayersBoundariesElements = () =>
     layersLib.FS_LAYERS.map((layer) => ({
@@ -46,7 +52,7 @@ module.exports = {
             {
                 "default": "disallow",
                 "message": "\"${file.type}\" is not allowed to import \"${dependency.type}\" | See rules: https://feature-sliced.design/docs/reference/layers/overview ",
-                "rules": [...getNotSharedLayersRules(), sharedLayerRule, ...getGodModeRules()],
+                "rules": [...getNotSharedLayersRules(), ...slicelessLayerRules, ...getGodModeRules()],
             },
         ],
     },

--- a/rules/layers-slices/layers.test.js
+++ b/rules/layers-slices/layers.test.js
@@ -102,4 +102,26 @@ describe("Import boundaries between layers", () => {
         assert.strictEqual(report[0].errorCount, 0);
     });
 
+    it("should lint without errors when import from app.", async () => {
+        const validCodeSnippet = [
+            `import "app/styles/styles.css"`,
+            `import { withProviders } from "app/providers"`,
+        ].join("\n");
+
+        const report = await eslint.lintText(validCodeSnippet, {
+            filePath: "src/app/ui/app.tsx",
+        });
+        assert.strictEqual(report[0].errorCount, 0);
+    });
+
+    it("should lint with errors when import from app.", async () => {
+        const wrongImports = [
+            `import { withProviders } from "app/providers"`,
+        ];
+
+        const report = await eslint.lintText(wrongImports.join("\n"), {
+            filePath: "src/features/add-user/model.tsx",
+        });
+        assert.strictEqual(report[0].errorCount, wrongImports.length);
+    });
 });


### PR DESCRIPTION
## Description

I came across the fact that with deafult config settings it is impossible to import internal modules inside the app layer. It seems to me that this is more of an error in the development of the config than a well-thought-out limitation.

For example, it is common to import styles or providers into the root of the app layer:

![image](https://github.com/feature-sliced/eslint-config/assets/166542865/b12f436b-969f-4da7-a393-dbc7c2796c77)

This pull request adds the ability to  cross-segment module imports  in the app layer.

## References
<!-- 2. References to issue, PR or discussions  -->
## Checklist
- [ ] Description added
- [ ] Self-reviewed
- [ ] CI pass
